### PR TITLE
⚡ Bolt: Cache cursor color to prevent layout thrashing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Avoid getComputedStyle in loops
+**Learning:** `getComputedStyle` forces a synchronous style recalculation (reflow) which is extremely expensive when called inside a `requestAnimationFrame` loop (60fps).
+**Action:** Cache the style value (e.g., color) in a variable and update it only when necessary (e.g., using `MutationObserver` or specific event listeners) instead of reading it every frame.


### PR DESCRIPTION
💡 What: Caches the cursor color in `CursorManager` instead of querying it every frame.
🎯 Why: `getComputedStyle` causes layout thrashing when called in a render loop.
📊 Impact: Eliminates 60 calls/sec to `getComputedStyle` for the cursor effect.
🔬 Measurement: Verified via benchmark and manual inspection of the render loop.

---
*PR created automatically by Jules for task [5312705964008889767](https://jules.google.com/task/5312705964008889767) started by @kaitoartz*