### PR TITLE
⚡ Bolt: Optimize Matrix Rain draw loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Avoid getComputedStyle in loops
 **Learning:** `getComputedStyle` forces a synchronous style recalculation (reflow) which is extremely expensive when called inside a `requestAnimationFrame` loop (60fps).
 **Action:** Cache the style value (e.g., color) in a variable and update it only when necessary (e.g., using `MutationObserver` or specific event listeners) instead of reading it every frame.
+
+## 2025-02-23 - Verify Comment Intent vs Implementation
+**Learning:** Code comments may describe optimizations that were never implemented or were removed, leading to misleading assumptions. The Matrix Rain loop claimed to "draw every second column" but actually iterated `i++`.
+**Action:** Always verify that the code logic matches the comments, especially when performance claims are made. Implement the missing optimization if it aligns with the goals.

--- a/js/script.js
+++ b/js/script.js
@@ -3024,8 +3024,10 @@ class MatrixRain {
         this.ctx.fillStyle = '#39FF14';
         this.ctx.font = `${this.fontSize}px monospace`;
 
-        // Dibujar solo cada segunda columna para mejor rendimiento
-        for (let i = 0; i < this.drops.length; i++) {
+        // Dibujar solo cada segunda columna para mejor rendimiento (excepto en Ultra)
+        const step = (typeof performanceManager !== 'undefined' && performanceManager.currentPreset === 'ultra') ? 1 : 2;
+
+        for (let i = 0; i < this.drops.length; i += step) {
             const text = this.characters[Math.floor(Math.random() * this.characters.length)];
             const x = i * this.fontSize;
             const y = this.drops[i] * this.fontSize;


### PR DESCRIPTION
💡 What: Optimized the Matrix Rain animation loop to skip every second column when not in 'ultra' performance mode.
🎯 Why: The original code contained a comment "// Dibujar solo cada segunda columna para mejor rendimiento" but implemented a standard `i++` loop, missing the intended optimization.
📊 Impact: Reduces Canvas `fillText` calls by 50% on High/Medium/Low presets, reducing CPU/GPU load on less capable devices.
🔬 Measurement: Verified via code review and frontend execution logs confirming the logic triggers correctly based on performance preset.

---
*PR created automatically by Jules for task [11962502195365637888](https://jules.google.com/task/11962502195365637888) started by @kaitoartz*