### PR TITLE
⚡ Disable smooth touch scrolling on mobile

### DIFF
--- a/demos/hyper-scroll/src/script.js
+++ b/demos/hyper-scroll/src/script.js
@@ -105,7 +105,7 @@
             lerp: 0.08, // Increased weight for heavy feel
             direction: 'vertical',
             gestureDirection: 'vertical',
-            smoothTouch: true
+            smoothTouch: !isMobile
         });
 
         lenis.on('scroll', ({ scroll, velocity }) => {


### PR DESCRIPTION
💡 **What:** Disabled Lenis smooth scrolling (simulation) on mobile devices in the Hyper Scroll demo.
🎯 **Why:** Smooth scrolling simulation via JS can be heavy on mobile devices and often feels less natural than native inertia scrolling. Disabling it improves performance and user experience on smaller screens.
📊 **Measured Improvement:** Verified via script that `smoothTouch` is set to `false` when viewport width is 375px (mobile) and `true` when 1920px (desktop).


---
*PR created automatically by Jules for task [12171737885307741464](https://jules.google.com/task/12171737885307741464) started by @kaitoartz*