### PR TITLE
Replace placeholder image for CREHA BITAT project

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -2529,7 +2529,7 @@ class ProjectsManager {
             {
                 title: 'CREHA BITAT',
                 description: '🥈 2º Lugar Social Impact Jam. Videojuego con enfoque social y educativo.',
-                image: 'ruta/a/imagen_creha.jpg',
+                image: 'assets/projects/crehabitat.webp',
                 tags: ['Unity', 'Social Impact', '2D'],
                 category: 'web',
                 github: 'https://github.com/kaitoartz',


### PR DESCRIPTION
Replaced the placeholder image path for the CREHA BITAT project with the correct asset path.

- **File**: `js/script.js`
- **Change**: Updated image path in `ProjectsManager` class.
- **Verification**: Confirmed asset existence and validity via frontend rendering (using existing `ProjectManager` instance).


---
*PR created automatically by Jules for task [4146053830450986975](https://jules.google.com/task/4146053830450986975) started by @kaitoartz*