### PR TITLE
⚡ Bolt: Optimize ParallaxManager scroll performance

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -309,6 +309,10 @@ class PerformanceManager {
         layers.forEach(layer => {
             layer.style.display = enable ? 'block' : 'none';
         });
+
+        if (enable && this.parallaxInstance) {
+            this.parallaxInstance.requestTick();
+        }
     }
 
     toggleCursorTrail(enable) {
@@ -3098,7 +3102,8 @@ class ParallaxManager {
         this.layers = document.querySelectorAll('.parallax-layer');
         if (this.layers.length === 0) return;
 
-        window.addEventListener('scroll', () => this.requestTick());
+        // Optimization: Use passive listener to prevent blocking scroll
+        window.addEventListener('scroll', () => this.requestTick(), { passive: true });
         
         // Register with performance manager
         performanceManager.registerEffect('parallax', this);
@@ -3112,6 +3117,9 @@ class ParallaxManager {
     }
 
     requestTick() {
+        // Optimization: Skip calculations if effect is disabled
+        if (!performanceManager.effects.parallax) return;
+
         if (!this.ticking) {
             window.requestAnimationFrame(() => this.update());
             this.ticking = true;


### PR DESCRIPTION
💡 **What:**
- Added `{ passive: true }` to the `scroll` event listener in `ParallaxManager`.
- Added an early return check in `ParallaxManager.requestTick` to skip animation frame requests when the parallax effect is disabled in `PerformanceManager`.
- Updated `PerformanceManager.toggleParallax` to force a position sync when re-enabling the effect.

🎯 **Why:**
- The scroll listener was blocking the main thread unnecessarily (default behavior without passive flag).
- The parallax loop continued to consume CPU cycles even when the effect was visually disabled by the user or performance monitor.

📊 **Impact:**
- Reduces main thread blocking during scrolling.
- Prevents wasted CPU cycles when parallax is off.

🔬 **Measurement:**
- Verified via static analysis (`node --check`).
- Verified via Playwright smoke test (`verify_parallax.py`) to ensure no regressions in visual rendering.

---
*PR created automatically by Jules for task [10881420647739092652](https://jules.google.com/task/10881420647739092652) started by @kaitoartz*