### PR TITLE
⚡ Bolt: Defer Matrix Rain until Intro completion

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1102,6 +1102,13 @@ class HyperScrollIntro {
                 if(main) {
                     main.style.animation = "fadeIn 1s ease forwards";
                 }
+
+                // Optimization: Start background effects now that they are visible
+                if (typeof matrixRain !== 'undefined' &&
+                    typeof performanceManager !== 'undefined' &&
+                    performanceManager.effects.matrixRain) {
+                     matrixRain.start(true);
+                }
                 
                 // Optional: Trigger legacy boot sequence visuals briefly or just logging
                 // For now, we assume direct access to dashboard
@@ -3092,7 +3099,10 @@ class MatrixRain {
         }
     }
 
-    start() {
+    start(force = false) {
+        // Optimization: Don't start if Intro is active to save resources
+        if (!force && typeof hyperIntro !== 'undefined' && hyperIntro.state.active) return;
+
         if (this.isActive) return;
         this.isActive = true;
         this.canvas.style.opacity = '0.15';


### PR DESCRIPTION
Prevents the Matrix Rain canvas draw loop from running while it is obscured by the opaque Hyper Scroll Intro overlay. The effect is now explicitly started (forced) only after the intro sequence finishes and the dashboard becomes visible.

**Changes:**
- Modified `MatrixRain.start()` to accept a `force` parameter and check `hyperIntro.state.active`.
- Updated `HyperScrollIntro.endIntro()` to call `matrixRain.start(true)` upon completion.

**Impact:**
- Reduces CPU/GPU usage during the initial intro sequence by pausing hidden canvas rendering.
- Prevents resource contention between the Intro animation and background effects.

---
*PR created automatically by Jules for task [16674843069170888644](https://jules.google.com/task/16674843069170888644) started by @kaitoartz*