### PR TITLE
⚡ Bolt: Fix PerformanceManager hardware detection

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -117,7 +117,8 @@ class PerformanceManager {
         this.parallaxInstance = null;
         this.cursorInstance = null;
         this.terminalInstance = null;
-        this.detectHardware(); // Call detectHardware to set initial tier
+        // Fix: Store the result of detectHardware in this.hardware
+        this.hardware = { ...this.hardware, ...this.detectHardware() };
     }
 
     detectHardware() {


### PR DESCRIPTION
This PR fixes a critical bug in `PerformanceManager` where the result of `detectHardware()` was being ignored during initialization. 

**Impact:**
- **Mobile Performance:** Drastically improved. `isMobile` is now correctly set to true on mobile devices.
- **Matrix Rain:** Now respects device capabilities, rendering at 1x scale on mobile instead of native DPR (often 3x), reducing pixel count by ~9x.
- **Scrolling:** Lenis smooth scroll is now correctly disabled on mobile, restoring native scroll performance and feel.
- **Hardware Tier:** Low-end devices will now correctly default to 'low' or 'medium' presets instead of 'high'.

**Verification:**
- Validated via reproduction script that `this.hardware` is now correctly populated with detection results.
- Verified syntax correctness of `js/script.js`.

---
*PR created automatically by Jules for task [16793586512650282226](https://jules.google.com/task/16793586512650282226) started by @kaitoartz*