### PR TITLE
⚡ Bolt: Optimize ParallaxManager Scroll Loop

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -3139,8 +3139,14 @@ class ParallaxManager {
     }
 
     init() {
-        this.layers = document.querySelectorAll('.parallax-layer');
-        if (this.layers.length === 0) return;
+        const elements = document.querySelectorAll('.parallax-layer');
+        if (elements.length === 0) return;
+
+        // Optimization: Cache elements and parse speeds once
+        this.layers = Array.from(elements).map(el => ({
+            el,
+            speed: parseFloat(el.dataset.speed) || 0.5
+        }));
 
         // Optimization: Use passive listener to prevent blocking scroll
         window.addEventListener('scroll', () => this.requestTick(), { passive: true });
@@ -3150,7 +3156,7 @@ class ParallaxManager {
         
         // Apply initial state
         if (!performanceManager.effects.parallax) {
-            this.layers.forEach(layer => layer.style.display = 'none');
+            this.layers.forEach(item => item.el.style.display = 'none');
         }
         
         devLog('Parallax initialized with', this.layers.length, 'layers');
@@ -3169,10 +3175,9 @@ class ParallaxManager {
     update() {
         this.lastScrollY = window.scrollY;
         
-        this.layers.forEach(layer => {
-            const speed = parseFloat(layer.dataset.speed) || 0.5;
-            const yPos = -(this.lastScrollY * speed);
-            layer.style.transform = `translate3d(0, ${yPos}px, 0)`;
+        this.layers.forEach(item => {
+            const yPos = -(this.lastScrollY * item.speed);
+            item.el.style.transform = `translate3d(0, ${yPos}px, 0)`;
         });
 
         this.ticking = false;


### PR DESCRIPTION
💡 **What**: Optimized `ParallaxManager` in `js/script.js`.
🎯 **Why**: Reading `dataset.speed` and calling `parseFloat` inside the scroll event listener (even inside `requestAnimationFrame`) is unnecessary overhead.
📊 **Impact**: Reduces layout thrashing and JS execution time during scrolling by caching static values.
🔬 **Measurement**: Verified functionality with Playwright script (parallax effect still works).

---
*PR created automatically by Jules for task [17670971458773322318](https://jules.google.com/task/17670971458773322318) started by @kaitoartz*