### PR TITLE
⚡ Bolt: Optimize HyperScrollIntro DOM updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2025-02-23 - Reliable Throttling in RAF
 **Learning:** Relying on `rafId % N` or `time % N` for throttling updates inside `requestAnimationFrame` is unreliable because `rafId` is not guaranteed to be sequential and `time` is high-precision float.
 **Action:** Use a dedicated `this.frameCount` variable incremented every frame for deterministic throttling (e.g., `if (this.frameCount % 10 === 0)`).
+
+## 2025-02-23 - Dirty Checking in RAF Loops
+**Learning:** Updating DOM properties like `style.opacity` or `style.transform` every frame, even with the same value, triggers browser work (style recalc). In scenes with many objects (like the Intro sequence), this adds up.
+**Action:** Cache the last applied value (e.g., `item.currentAlpha`) and strictly compare it with the new value before writing to the DOM. Use `Math.abs(diff) > epsilon` for floats to avoid noise.

--- a/js/script.js
+++ b/js/script.js
@@ -840,7 +840,9 @@ class HyperScrollIntro {
                 this.items.push({
                     el, type: 'text',
                     x: 0, y: 0, rot: 0,
-                    baseZ: -i * this.config.zGap
+                    baseZ: -i * this.config.zGap,
+                    currentAlpha: -1,
+                    currentTrans: null
                 });
             } else {
                 const card = document.createElement('div');
@@ -869,7 +871,9 @@ class HyperScrollIntro {
                 this.items.push({
                     el, type: 'card',
                     x, y, rot,
-                    baseZ: -i * this.config.zGap
+                    baseZ: -i * this.config.zGap,
+                    currentAlpha: -1,
+                    currentTrans: null
                 });
             }
             this.world.appendChild(el);
@@ -884,7 +888,9 @@ class HyperScrollIntro {
                 el, type: 'star',
                 x: (Math.random() - 0.5) * 3000,
                 y: (Math.random() - 0.5) * 3000,
-                baseZ: -Math.random() * this.config.loopSize
+                baseZ: -Math.random() * this.config.loopSize,
+                currentAlpha: -1,
+                currentTrans: null
             });
         }
     }
@@ -1039,7 +1045,11 @@ class HyperScrollIntro {
                 if (vizZ > 100 && item.type !== 'star') alpha = 1 - ((vizZ - 100) / 400); // Fade out close
                 if (alpha < 0) alpha = 0;
                 
-                item.el.style.opacity = alpha;
+                // Optimization: Update opacity only if changed significantly
+                if (Math.abs(item.currentAlpha - alpha) > 0.001) {
+                    item.el.style.opacity = alpha;
+                    item.currentAlpha = alpha;
+                }
 
                 if (alpha > 0) {
                     let trans = `translate3d(${item.x}px, ${item.y}px, ${vizZ}px)`;
@@ -1061,7 +1071,12 @@ class HyperScrollIntro {
                         const float = Math.sin(t + item.x) * 10;
                         trans += ` rotateZ(${item.rot}deg) rotateY(${float}deg)`;
                     }
-                    item.el.style.transform = trans;
+
+                    // Optimization: Update transform only if changed
+                    if (item.currentTrans !== trans) {
+                        item.el.style.transform = trans;
+                        item.currentTrans = trans;
+                    }
                 }
             });
         };


### PR DESCRIPTION
💡 What: Implemented "dirty checking" for DOM updates in the `HyperScrollIntro` animation loop.
🎯 Why: The intro animation updates ~170 elements every frame (60fps). Updating `style.opacity` and `style.transform` unconditionally triggers browser style recalculation and layout thrashing, even if the values haven't changed (e.g., stars far away with opacity 0, or stars in the middle with opacity 1).
📊 Impact: Reduces unnecessary DOM writes. For items with static opacity (most stars), it skips the style update entirely. This frees up the main thread and reduces CPU usage during the heavy intro sequence.
🔬 Measurement: Verified via code inspection and frontend screenshot (ensuring no visual regression). Logic uses `currentAlpha` and `currentTrans` caching.

---
*PR created automatically by Jules for task [2472208942390831986](https://jules.google.com/task/2472208942390831986) started by @kaitoartz*