### PR TITLE
Fix control dock visibility during intro animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Zalando+Sans:ital,wght@0,200..900;1,200..900&display=swap"
     rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/src/styles/styles.css">
+    <link rel="stylesheet" href="src/styles/styles.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"> 
 
 <!-- JSON-LD Structured Data for SEO -->
@@ -795,10 +795,12 @@
     <!-- LENIS FOR SMOOTH SCROLL (Hyper Intro) -->
     <script src="https://unpkg.com/@studio-freight/lenis@1.0.33/dist/lenis.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js" defer></script>
-    <script type="module" src="/src/scripts/script.js" defer></script>
+    <script type="module" src="src/scripts/script.js" defer></script>
     
+    </div>
+
     <!-- CONTROL DOCK -->
-    <div class="control-dock collapsed" data-expanded="false">
+    <div class="control-dock" data-expanded="true">
         <div class="dock-deco-start">
             <div class="dock-lines">
                 <span></span><span></span><span></span>
@@ -824,7 +826,6 @@
 <div class="dock-deco-end">
     <span class="dock-label-min">SYS</span>
 </div>
-    </div>
     </div>
 </body>
 </html>

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -3658,9 +3658,9 @@ body,
 /* ========== NO SCROLL UTILITY ========== */
 
 /* Hide controls during loading (when no-scroll is active) */
-.no-scroll .control-dock {
+/* .no-scroll .control-dock {
     display: none !important;
-}
+} */
 /* ========== CUSTOM CURSOR ========== */
 body {
     cursor: none;
@@ -4140,7 +4140,7 @@ a, button, .link-block, .stat-box {
                 0 100%,
                 0 10px);
     backdrop-filter: blur(10px);
-    z-index: 9999;
+    z-index: 10010;
     /* Use drop-shadow for outer glow with clip-path, keep box-shadow for inset */
         box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.5);
         filter: drop-shadow(0 0 5px var(--shadow-color)) drop-shadow(0 0 15px rgba(0, 0, 0, 0.8));


### PR DESCRIPTION
- Moved `.control-dock` outside of `#body-content` in `index.html` to prevent it from being hidden when the main content is hidden.
- Increased `.control-dock` z-index to `10010` in `src/styles/styles.css` to appear above the intro layer (z-index 10000).
- Disabled the CSS rule `.no-scroll .control-dock { display: none !important; }` to allow dock visibility during the intro sequence.
- Fixed relative paths for CSS and JS in `index.html`.
- Set control dock to expanded state by default in `index.html`.

---
*PR created automatically by Jules for task [18037959285266510280](https://jules.google.com/task/18037959285266510280) started by @kaitoartz*