### PR TITLE
⚡ Bolt: Optimize HyperScrollIntro by caching DOM queries and removing layout thrashing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 ## 2025-02-23 - Disable Lenis on Mobile
 **Learning:** Lenis smooth scrolling library was initialized on mobile devices in "Physical Mode" (Low/Medium tier), causing "scroll hijacking" and potentially degrading performance/UX by overriding native smooth scroll.
 **Action:** Explicitly check `!isMobileBrowser` (or `!performanceManager.hardware.isMobile`) before initializing scroll hijacking libraries, ensuring mobile users get the native, hardware-accelerated scroll experience.
+## 2024-05-20 - Expensive DOM Query in rAF Loop
+**Learning:** Found a severe performance bottleneck where `querySelector('.intro-card')` was executed per item every frame (~1200+ calls/sec) inside `HyperScrollIntro.startLoop()`. This is a classic anti-pattern for canvas/animation loops.
+**Action:** Always cache DOM elements like `cardEl` during initialization (`createWorld`) instead of querying them inside `requestAnimationFrame`. Use state tracking flags (e.g., `isCardActive`) to avoid redundantly setting identical DOM classes every frame.

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -960,6 +960,8 @@ class HyperScrollIntro {
 
                 this.items.push({
                     el, type: 'card',
+                    cardEl: card,
+                    isCardActive: false,
                     x, y, rot,
                     baseZ: -i * this.config.zGap,
                     currentAlpha: -1,
@@ -1118,10 +1120,10 @@ class HyperScrollIntro {
             
             // HUD Updates Throttled
             if (this.frameCount % 10 === 0) {
-                if (this.feedbackFPS) this.feedbackFPS.innerText = fps;
-                if (this.feedbackVel) this.feedbackVel.innerText = Math.abs(this.state.velocity).toFixed(2);
+                if (this.feedbackFPS) this.feedbackFPS.textContent = fps;
+                if (this.feedbackVel) this.feedbackVel.textContent = Math.abs(this.state.velocity).toFixed(2);
                 if (this.feedbackCoord) {
-                    this.feedbackCoord.innerText = this.isVirtualMode ? "∞" : this.state.scroll.toFixed(0);
+                    this.feedbackCoord.textContent = this.isVirtualMode ? "∞" : this.state.scroll.toFixed(0);
                 }
             }
 
@@ -1221,10 +1223,13 @@ class HyperScrollIntro {
                         // Card Logic
                         if (this.isHyperEnabled) {
                             // AUTO-ANIMATION: Trigger .is-active when card is in focus range
-                            const cardEl = item.el.querySelector('.intro-card');
+                            const cardEl = item.cardEl;
                             if (cardEl) {
                                 const isInFocus = vizZ > -400 && vizZ < 400;
-                                cardEl.classList.toggle('is-active', isInFocus);
+                                if (isInFocus !== item.isCardActive) {
+                                    cardEl.classList.toggle('is-active', isInFocus);
+                                    item.isCardActive = isInFocus;
+                                }
                             }
 
                             const t = time * 0.001;


### PR DESCRIPTION
⚡ Bolt: Optimize HyperScrollIntro by caching DOM queries and removing layout thrashing

💡 What:
1. Cached `.intro-card` DOM element resolution (`cardEl`) during initialization inside `createWorld` instead of querying per-item within the `requestAnimationFrame` loop.
2. Implemented `isCardActive` state flag to prevent redundant `.classList.toggle('is-active', ...)` calls on each frame.
3. Swapped `innerText` to `textContent` in `HUD` updates to stop synchronous layout thrashing.

🎯 Why:
Inside `HyperScrollIntro.startLoop()`, `item.el.querySelector('.intro-card')` was firing up to 1200+ times per second (20 items * 60 fps). Constant DOM querying and unnecessary class toggling cause massive main thread CPU load, risking frame drops. Writing to `.innerText` similarly forces style recalcs.

📊 Impact:
- Drastically reduces main thread idle time consumption.
- Eliminates 1200+ redundant DOM queries/sec.
- Removes synchronous layout recalculations during HUD render.

🔬 Measurement:
Run the page with Performance devtools. The `HyperScrollIntro.startLoop` self time will be near-zero with significantly reduced Recalculate Style & Layout tasks.

---
*PR created automatically by Jules for task [12683249735329332755](https://jules.google.com/task/12683249735329332755) started by @kaitoartz*