### PR TITLE
⚡ Bolt: Replace MutationObserver with Event Delegation in AudioManager

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,11 @@
 ## 2025-02-23 - Disable Lenis on Mobile
 **Learning:** Lenis smooth scrolling library was initialized on mobile devices in "Physical Mode" (Low/Medium tier), causing "scroll hijacking" and potentially degrading performance/UX by overriding native smooth scroll.
 **Action:** Explicitly check `!isMobileBrowser` (or `!performanceManager.hardware.isMobile`) before initializing scroll hijacking libraries, ensuring mobile users get the native, hardware-accelerated scroll experience.
+
+## 2025-02-23 - Event Delegation Over MutationObserver
+**Learning:** Attaching event listeners (like `mouseenter`) dynamically via `MutationObserver` creates overhead, as the observer triggers on multiple DOM changes and executes heavy query/attachment logic.
+**Action:** Replace `MutationObserver`-based listener attachments with a single, passive `mouseover` listener attached to the `document` (event delegation). Use `e.target.closest(selector)` to identify targets.
+
+## 2025-02-23 - Nested Elements in Event Delegation
+**Learning:** When using `mouseover` delegation, moving the mouse from a child element back to a parent element that matches the same selector can cause `target !== this.lastHoveredTarget` to evaluate as true, incorrectly re-triggering hover sounds.
+**Action:** In addition to `target !== this.lastHoveredTarget`, add a check `!target.contains(this.lastHoveredTarget)` to prevent re-triggering when navigating within nested matched elements. Ensure `this.lastHoveredTarget = target` is always updated to properly track the path.

--- a/js/script.js
+++ b/js/script.js
@@ -694,11 +694,14 @@ class AudioManager {
         const target = e.target.closest(selector);
 
         // Optimization: Only play if we entered a NEW target
+        // and we haven't moved to a child of the current target
         if (target) {
-            if (target !== this.lastHoveredTarget) {
+            if (target !== this.lastHoveredTarget && (!this.lastHoveredTarget || !target.contains(this.lastHoveredTarget))) {
                 this.playHover();
-                this.lastHoveredTarget = target;
             }
+            // Always update lastHoveredTarget to the closest matching parent/element
+            // to correctly track nested elements
+            this.lastHoveredTarget = target;
         } else {
             this.lastHoveredTarget = null;
         }

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -597,9 +597,6 @@ class AudioManager {
         this.mediaSource = null;
         this.analyserNode = null;
         
-        // Performance optimization: Bind playHover once
-        this.boundPlayHover = this.playHover.bind(this);
-
         // Audio file paths
         this.audioFiles = {
             background: ASSET_PATH + 'audio/background.mp3'
@@ -607,6 +604,7 @@ class AudioManager {
         
         // Safety for async race conditions
         this.playPromise = null;
+        this.lastHoveredTarget = null;
     }
 
     async init() {
@@ -774,45 +772,31 @@ class AudioManager {
         this.playSound('click', 0.3); // Reusing click as typing sound for now, usually short
     }
 
-    addHoverListeners(root) {
+    handleMouseOver(e) {
+        if (!this.enabled) return;
+
         const selector = 'a, button, input, textarea, .project-card, .filter-btn';
+        const target = e.target.closest(selector);
 
-        // Helper to attach listener safely
-        const attach = (el) => {
-            el.removeEventListener('mouseenter', this.boundPlayHover);
-            el.addEventListener('mouseenter', this.boundPlayHover);
-        };
-
-        // If the root element itself matches
-        if (root.matches && root.matches(selector)) {
-            attach(root);
-        }
-
-        // Find all matching children
-        if (root.querySelectorAll) {
-            root.querySelectorAll(selector).forEach(attach);
+        // Optimization: Only play if we entered a NEW target
+        // and we haven't moved to a child of the current target
+        if (target) {
+            if (target !== this.lastHoveredTarget && (!this.lastHoveredTarget || !target.contains(this.lastHoveredTarget))) {
+                this.playHover();
+            }
+            // Always update lastHoveredTarget to the closest matching parent/element
+            // to correctly track nested elements
+            this.lastHoveredTarget = target;
+        } else {
+            this.lastHoveredTarget = null;
         }
     }
 
     attachGlobalListeners() {
-        // Universal Hover - Optimized with MutationObserver and direct listeners
-        this.addHoverListeners(document);
-
-        const observer = new MutationObserver((mutations) => {
-            mutations.forEach((mutation) => {
-                mutation.addedNodes.forEach((node) => {
-                    if (node.nodeType === 1) { // Element
-                        this.addHoverListeners(node);
-                    }
-                });
-            });
-        });
-
-        observer.observe(document.body, { childList: true, subtree: true });
+        // Universal Hover - Optimized with Event Delegation
+        document.addEventListener('mouseover', this.handleMouseOver.bind(this), { passive: true });
 
         // Typing Sound Generators
-        const typingInputs = document.querySelectorAll('input[type="text"], input[type="email"], textarea, .terminal-input');
-
         // Delegate for dynamic elements (like terminal)
         document.addEventListener('input', (e) => {
             if (e.target.matches('input, textarea')) {


### PR DESCRIPTION
💡 What: Replaced the resource-heavy `MutationObserver` (which watched DOM mutations to attach individual `mouseenter` listeners) with a single `mouseover` event delegation listener attached to the `document`. Implemented a robust check (`!target.contains(this.lastHoveredTarget)`) to prevent redundant sound triggers when navigating nested elements.
🎯 Why: `MutationObserver` and individual listeners scale poorly, causing significant overhead (DOM thrashing, memory bloat) when dynamically rendering or modifying interactive elements (like project cards). Event delegation is standard, lighter, and O(1) in terms of listener instances.
📊 Impact: Reduces memory footprint by eliminating N event listeners (where N is the number of interactive elements) and stops continuous DOM checking via MutationObserver. Results in smoother performance during rendering/filtering.
🔬 Measurement: Verify that hover sounds trigger correctly on interactive elements (buttons, links, project cards) without playing multiple times when moving across nested children (e.g. from an icon back to the button boundary).

---
*PR created automatically by Jules for task [10688280299018304625](https://jules.google.com/task/10688280299018304625) started by @kaitoartz*