### PR TITLE
Store `detectHardware` result directly in `this.hardware`

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -107,18 +107,12 @@ class PerformanceManager {
             visualizer: true
         };
         this.currentPreset = 'auto'; // auto, ultra, high, medium, low
-        this.hardware = {
-            cores: navigator.hardwareConcurrency || 4,
-            memory: navigator.deviceMemory || 4,
-            gpu: 'unknown',
-            tier: 'high' // ultra, high, medium, low
-        };
         this.matrixRainInstance = null;
         this.parallaxInstance = null;
         this.cursorInstance = null;
         this.terminalInstance = null;
         // Fix: Store the result of detectHardware in this.hardware
-        this.hardware = { ...this.hardware, ...this.detectHardware() };
+        this.hardware = this.detectHardware();
     }
 
     detectHardware() {
@@ -159,6 +153,7 @@ class PerformanceManager {
             isMobile,
             cores,
             memory,
+            gpu: 'unknown',
             connection: effectiveType,
             score,
             tier: this.getPerformanceTier(score)

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -109,18 +109,12 @@ class PerformanceManager {
             visualizer: true
         };
         this.currentPreset = 'auto'; // auto, ultra, high, medium, low
-        this.hardware = {
-            cores: navigator.hardwareConcurrency || 4,
-            memory: navigator.deviceMemory || 4,
-            gpu: 'unknown',
-            tier: 'high' // ultra, high, medium, low
-        };
         this.matrixRainInstance = null;
         this.parallaxInstance = null;
         this.cursorInstance = null;
         this.terminalInstance = null;
         // Fix: Store the result of detectHardware in this.hardware
-        this.hardware = { ...this.hardware, ...this.detectHardware() };
+        this.hardware = this.detectHardware();
     }
 
     detectHardware() {
@@ -181,6 +175,7 @@ class PerformanceManager {
             isMobile,
             cores,
             memory,
+            gpu: 'unknown',
             connection: effectiveType,
             batteryLevel,
             isCharging,


### PR DESCRIPTION
Replaced a two-step `this.hardware` instantiation (default values followed by an object spread merge) with a direct assignment of `this.detectHardware()` in the `PerformanceManager` constructor. I also added the missing `gpu: 'unknown'` key directly to the `detectHardware` return object to maintain parity with the original defaults. Modified both `js/script.js` and `src/scripts/script.js` for parity.

---
*PR created automatically by Jules for task [1384250399777722353](https://jules.google.com/task/1384250399777722353) started by @kaitoartz*