### PR TITLE
⚡ Bolt: Eliminate O(N) DOM queries inside requestAnimationFrame loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,7 @@
 ## 2025-02-17 - Eliminate Layout Thrashing in `requestAnimationFrame`
 **Learning:** Using `.innerText` to update high-frequency text elements (like HUD stats or FPS counters) inside a `requestAnimationFrame` loop forces the browser to perform synchronous style recalculations and layout thrashing. This is because `.innerText` is layout-aware (it respects CSS styling like `display: none` and text transformations).
 **Action:** Always use `.textContent` for updating text nodes in animation loops, as it modifies the text directly without triggering expensive reflows.
+
+## 2025-02-23 - DOM Queries in Animation Loops
+**Learning:** Performing DOM queries like `querySelector` and modifying `classList` inside a 60fps `requestAnimationFrame` loop (e.g., in `HyperScrollIntro`) is extremely expensive, causing O(N) operations per frame and potential layout thrashing.
+**Action:** Cache DOM elements (like `cardEl`) during initialization and track active states (like `isCardActive`) using a boolean flag to only update the DOM when the state actually changes.

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -1010,6 +1010,8 @@ class HyperScrollIntro {
 
                 this.items.push({
                     el, type: 'card',
+                    cardEl: card,
+                    isCardActive: false,
                     x, y, rot,
                     baseZ: -i * this.config.zGap,
                     currentAlpha: -1,
@@ -1283,11 +1285,19 @@ class HyperScrollIntro {
                     } else {
                         // Card Logic
                         if (this.isHyperEnabled) {
+                            /**
+                             * ⚡ Bolt Performance Optimization
+                             * 💡 What: Replaced DOM query `item.el.querySelector` inside requestAnimationFrame with a cached reference `item.cardEl`, and added state tracking `item.isCardActive` to prevent redundant `classList.toggle` calls.
+                             * 🎯 Why: Querying the DOM and invoking classList operations on every frame (60fps) for multiple elements causes layout thrashing and unnecessary CPU overhead.
+                             * 📊 Impact: Eliminates O(N) DOM queries and DOM writes per frame, ensuring smoother 60fps rendering during the intro sequence.
+                             */
                             // AUTO-ANIMATION: Trigger .is-active when card is in focus range
-                            const cardEl = item.el.querySelector('.intro-card');
-                            if (cardEl) {
+                            if (item.cardEl) {
                                 const isInFocus = vizZ > -400 && vizZ < 400;
-                                cardEl.classList.toggle('is-active', isInFocus);
+                                if (item.isCardActive !== isInFocus) {
+                                    item.cardEl.classList.toggle('is-active', isInFocus);
+                                    item.isCardActive = isInFocus;
+                                }
                             }
 
                             const t = time * 0.001;


### PR DESCRIPTION
💡 **What:** Caches the `.intro-card` DOM element reference during the `HyperScrollIntro` initialization and tracks its active state (`isCardActive`) to conditionally update its class only when the state changes. 

🎯 **Why:** Inside the 60fps `requestAnimationFrame` loop (`HyperScrollIntro.startLoop()`), calling `querySelector('.intro-card')` and indiscriminately calling `classList.toggle()` for potentially hundreds of items causes O(N) DOM read/write operations per frame. This is a severe anti-pattern that leads to unnecessary CPU overhead, GC pressure, and layout thrashing, especially on low-end and mobile devices.

📊 **Impact:** Reduces DOM read/write operations for `.intro-card` elements from O(N) per frame (N = number of intro items) to 0 operations per frame, strictly executing a single write ONLY when an item enters or exits the focus range. CPU usage during the intro sequence should be measurably lower.

🔬 **Measurement:** Use Chrome DevTools Performance tab to profile the intro scroll sequence before and after this change. Observe the reduction in the amount of time spent in "Scripting" and "Rendering" phases, specifically the elimination of repeated `querySelector` calls in the flame chart.

---
*PR created automatically by Jules for task [8938071672307508152](https://jules.google.com/task/8938071672307508152) started by @kaitoartz*