### PR TITLE
⚡ Bolt: Optimize ParallaxManager scrolling with IntersectionObserver and dirty checking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -51,3 +51,7 @@
 ## 2025-05-15 - requestAnimationFrame for DOM Animations
 **Learning:** `setInterval` for animations operates independently of the screen refresh rate, leading to visual jitter, and it continues running even when the tab is backgrounded.
 **Action:** Replace `setInterval` with `requestAnimationFrame` for DOM animations (like count-ups) to guarantee smooth execution matched to the monitor's refresh rate and automatically pause when the tab is off-screen.
+
+## 2025-05-18 - Parallax Off-screen Optimization
+**Learning:** Updating CSS transforms on off-screen elements during high-frequency events (like scroll) wastes CPU/GPU resources and can cause layer tree recalculations, even if the elements are invisible. Furthermore, updating the DOM for imperceptible sub-pixel changes causes redundant layout and compositing work.
+**Action:** Use `IntersectionObserver` with a generous `rootMargin` (e.g., `100%`) to flag when parallax elements are safely out of view to skip their `style.transform` updates. Combine this with a dirty check (`Math.abs(lastYPos - yPos) > 0.5`) to eliminate sub-pixel DOM writes.

--- a/js/script.js
+++ b/js/script.js
@@ -3278,8 +3278,27 @@ class ParallaxManager {
         // Optimization: Pre-calculate speed and cache elements to avoid DOM access in loop
         this.items = Array.from(layers).map(layer => ({
             el: layer,
-            speed: parseFloat(layer.dataset.speed) || 0.5
+            speed: parseFloat(layer.dataset.speed) || 0.5,
+            isVisible: true, // Assume visible initially
+            lastYPos: undefined
         }));
+
+        // Optimization: Use IntersectionObserver to skip DOM updates for off-screen layers
+        this.observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                const item = this.items.find(i => i.el === entry.target);
+                if (item) {
+                    item.isVisible = entry.isIntersecting;
+                    // Trigger an immediate update when an element becomes visible
+                    // to fix stale positions after sudden anchor jumps
+                    if (item.isVisible) {
+                        this.requestTick();
+                    }
+                }
+            });
+        }, { rootMargin: '100% 0px' }); // Margin to ensure it starts moving before entering viewport
+
+        this.items.forEach(item => this.observer.observe(item.el));
 
         // Optimization: Use passive listener to prevent blocking scroll
         window.addEventListener('scroll', () => this.requestTick(), { passive: true });
@@ -3312,8 +3331,21 @@ class ParallaxManager {
         
         for (let i = 0; i < this.items.length; i++) {
             const item = this.items[i];
+
+            /**
+             * ⚡ Bolt Performance Optimization
+             * 💡 What: Implemented IntersectionObserver to skip off-screen elements and added dirty checking for sub-pixel changes.
+             * 🎯 Why: Modifying `style.transform` unconditionally on every scroll tick for off-screen elements or for imperceptible sub-pixel changes forces unnecessary layer compositing and CPU/GPU work.
+             * 📊 Impact: Eliminates DOM writes for off-screen parallax layers (saving O(N) operations) and prevents redundant sub-pixel layout thrashing.
+             */
+            if (!item.isVisible) continue;
+
             const yPos = -(this.lastScrollY * item.speed);
-            item.el.style.transform = `translate3d(0, ${yPos}px, 0)`;
+
+            if (item.lastYPos === undefined || Math.abs(item.lastYPos - yPos) > 0.5) {
+                item.el.style.transform = `translate3d(0, ${yPos}px, 0)`;
+                item.lastYPos = yPos;
+            }
         }
 
         this.ticking = false;

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -3770,8 +3770,27 @@ class ParallaxManager {
         // Optimization: Pre-calculate speed and cache elements to avoid DOM access in loop
         this.items = Array.from(layers).map(layer => ({
             el: layer,
-            speed: parseFloat(layer.dataset.speed) || 0.5
+            speed: parseFloat(layer.dataset.speed) || 0.5,
+            isVisible: true, // Assume visible initially
+            lastYPos: undefined
         }));
+
+        // Optimization: Use IntersectionObserver to skip DOM updates for off-screen layers
+        this.observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                const item = this.items.find(i => i.el === entry.target);
+                if (item) {
+                    item.isVisible = entry.isIntersecting;
+                    // Trigger an immediate update when an element becomes visible
+                    // to fix stale positions after sudden anchor jumps
+                    if (item.isVisible) {
+                        this.requestTick();
+                    }
+                }
+            });
+        }, { rootMargin: '100% 0px' }); // Margin to ensure it starts moving before entering viewport
+
+        this.items.forEach(item => this.observer.observe(item.el));
 
         // Optimization: Use passive listener to prevent blocking scroll
         window.addEventListener('scroll', () => this.requestTick(), { passive: true });
@@ -3804,8 +3823,21 @@ class ParallaxManager {
         
         for (let i = 0; i < this.items.length; i++) {
             const item = this.items[i];
+
+            /**
+             * ⚡ Bolt Performance Optimization
+             * 💡 What: Implemented IntersectionObserver to skip off-screen elements and added dirty checking for sub-pixel changes.
+             * 🎯 Why: Modifying `style.transform` unconditionally on every scroll tick for off-screen elements or for imperceptible sub-pixel changes forces unnecessary layer compositing and CPU/GPU work.
+             * 📊 Impact: Eliminates DOM writes for off-screen parallax layers (saving O(N) operations) and prevents redundant sub-pixel layout thrashing.
+             */
+            if (!item.isVisible) continue;
+
             const yPos = -(this.lastScrollY * item.speed);
-            item.el.style.transform = `translate3d(0, ${yPos}px, 0)`;
+
+            if (item.lastYPos === undefined || Math.abs(item.lastYPos - yPos) > 0.5) {
+                item.el.style.transform = `translate3d(0, ${yPos}px, 0)`;
+                item.lastYPos = yPos;
+            }
         }
 
         this.ticking = false;


### PR DESCRIPTION
⚡ **Bolt Performance Optimization: Parallax Manager**

**💡 What:** 
Implemented an `IntersectionObserver` in the `ParallaxManager` to track the visibility of parallax layers. The `requestAnimationFrame` update loop now explicitly skips DOM transform updates for any layer that is off-screen. Additionally, implemented a dirty check (`Math.abs(lastYPos - yPos) > 0.5`) to prevent `style.transform` updates when the scroll change results in imperceptible sub-pixel differences. Included an immediate `requestTick()` when an element comes into view to handle sudden anchor jumps cleanly.

**🎯 Why:**
Prior to this change, the `ParallaxManager` unconditionally calculated and applied `translate3d` to every registered parallax layer on every single scroll tick. For long pages with many layers, applying transforms to off-screen elements wastes CPU and GPU resources (layer tree recalculations and compositing). Furthermore, applying DOM updates for sub-pixel changes causes layout thrashing without any visible benefit to the user.

**📊 Impact:**
- Eliminates O(N) DOM writes for off-screen parallax layers.
- Prevents redundant sub-pixel layer compositing.
- Results in significantly smoother scrolling performance, especially on lower-end and mobile devices.

**🔬 Measurement:**
1. Scroll the page while observing the Performance tab in Chrome DevTools.
2. Note the reduced number of "Recalculate Style" and "Update Layer Tree" events compared to the previous implementation.
3. Check `ParallaxManager.update()` execution time.

Changes applied to both `src/scripts/script.js` and the corresponding `js/script.js` file for consistency. Logged learnings in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [13804861892299303171](https://jules.google.com/task/13804861892299303171) started by @kaitoartz*