### PR TITLE
⚡ Bolt: Cache canvas dimensions in RAF loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -55,3 +55,6 @@
 ## 2025-05-18 - Parallax Off-screen Optimization
 **Learning:** Updating CSS transforms on off-screen elements during high-frequency events (like scroll) wastes CPU/GPU resources and can cause layer tree recalculations, even if the elements are invisible. Furthermore, updating the DOM for imperceptible sub-pixel changes causes redundant layout and compositing work.
 **Action:** Use `IntersectionObserver` with a generous `rootMargin` (e.g., `100%`) to flag when parallax elements are safely out of view to skip their `style.transform` updates. Combine this with a dirty check (`Math.abs(lastYPos - yPos) > 0.5`) to eliminate sub-pixel DOM writes.
+## 2026-04-22 - Prevent DOM reads in requestAnimationFrame
+**Learning:** Reading DOM properties like `canvas.width` and `canvas.height` inside a high-frequency `requestAnimationFrame` loop forces synchronous JavaScript-to-C++ boundary crossings, causing performance overhead and potential layout thrashing.
+**Action:** Cache the required properties during initialization and resize events (e.g., `this.logicalWidth = this.canvas.width`), and use these cached properties exclusively within the animation loop to eliminate redundant DOM reads.

--- a/js/script.js
+++ b/js/script.js
@@ -1784,6 +1784,8 @@ class CursorManager {
         this.looping = false; // Tracks active RAF loop
         this.animationId = null;
         this.rgb = { r: 57, g: 255, b: 20 }; // Default toxic green
+        this.logicalWidth = 0;
+        this.logicalHeight = 0;
 
         this.animate = this.animate.bind(this);
     }
@@ -1844,8 +1846,10 @@ class CursorManager {
     }
 
     resize() {
-        this.canvas.width = window.innerWidth;
-        this.canvas.height = window.innerHeight;
+        this.logicalWidth = window.innerWidth;
+        this.logicalHeight = window.innerHeight;
+        this.canvas.width = this.logicalWidth;
+        this.canvas.height = this.logicalHeight;
         if (this.running && !this.looping) {
             this.looping = true;
             this.animate();
@@ -1870,7 +1874,7 @@ class CursorManager {
         }
         // Clear canvas when stopped
         if (this.ctx && this.canvas) {
-            this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+            this.ctx.clearRect(0, 0, this.logicalWidth || this.canvas.width, this.logicalHeight || this.canvas.height);
         }
         // Reset trail without destroying objects
         for (let i = 0; i < this.trail.length; i++) {
@@ -1878,13 +1882,19 @@ class CursorManager {
         }
     }
 
+    /**
+     * ⚡ Bolt Performance Optimization
+     * 💡 What: Cached `this.logicalWidth` and `this.logicalHeight` and used them instead of reading `this.canvas.width` and `this.canvas.height`.
+     * 🎯 Why: Reading DOM properties like `canvas.width` inside a high-frequency `requestAnimationFrame` loop forces synchronous C++ boundary crossings which adds CPU overhead.
+     * 📊 Impact: Eliminates O(N) DOM reads per frame, ensuring smoother rendering.
+     */
     animate() {
         if (!this.running) {
             this.looping = false;
             return;
         }
         
-        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.clearRect(0, 0, this.logicalWidth, this.logicalHeight);
         
         // Use cached RGB instead of calling getComputedStyle every frame
         const { r, g, b } = this.rgb;
@@ -2874,6 +2884,8 @@ class AudioVisualizer {
         this.animationId = null;
         this.gradientCache = [];
         this.lastHeight = 0;
+        this.logicalWidth = 0;
+        this.logicalHeight = 0;
 
         // Bind for RAF optimization
         this.draw = this.draw.bind(this);
@@ -2885,6 +2897,9 @@ class AudioVisualizer {
         
         this.ctx = this.canvas.getContext('2d');
         
+        this.logicalWidth = this.canvas.width;
+        this.logicalHeight = this.canvas.height;
+
         // Setup visibility observer to stop render loop when off-screen
         this.observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
@@ -2945,8 +2960,14 @@ class AudioVisualizer {
         this.analyser.getByteFrequencyData(this.dataArray);
         
         const ctx = this.ctx;
-        const width = this.canvas.width;
-        const height = this.canvas.height;
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Cached canvas dimensions as `this.logicalWidth` and `this.logicalHeight` to prevent reading DOM properties `this.canvas.width` and `this.canvas.height` on every frame.
+         * 🎯 Why: Accessing DOM properties inside a 60fps `requestAnimationFrame` loop forces synchronous JS-to-C++ boundary crossings, causing performance overhead.
+         * 📊 Impact: Eliminates DOM reads during the animation loop, reducing CPU usage.
+         */
+        const width = this.logicalWidth;
+        const height = this.logicalHeight;
         
         ctx.fillStyle = 'rgba(0, 0, 0, 0.2)';
         ctx.fillRect(0, 0, width, height);
@@ -2991,8 +3012,8 @@ class AudioVisualizer {
     drawStandby() {
         if (!this.canvas || !this.ctx) return;
         const ctx = this.ctx;
-        const width = this.canvas.width;
-        const height = this.canvas.height;
+        const width = this.logicalWidth || this.canvas.width;
+        const height = this.logicalHeight || this.canvas.height;
         
         ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
         ctx.fillRect(0, 0, width, height);

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -2255,6 +2255,8 @@ class CursorManager {
         this.looping = false; // Tracks active RAF loop
         this.animationId = null;
         this.rgb = { r: 57, g: 255, b: 20 }; // Default toxic green
+        this.logicalWidth = 0;
+        this.logicalHeight = 0;
 
         // PERF: Bind animate to prevent closure creation in RAF loop
         this.animate = this.animate.bind(this);
@@ -2316,8 +2318,10 @@ class CursorManager {
     }
 
     resize() {
-        this.canvas.width = window.innerWidth;
-        this.canvas.height = window.innerHeight;
+        this.logicalWidth = window.innerWidth;
+        this.logicalHeight = window.innerHeight;
+        this.canvas.width = this.logicalWidth;
+        this.canvas.height = this.logicalHeight;
         if (this.running && !this.looping) {
             this.looping = true;
             this.animate();
@@ -2342,7 +2346,7 @@ class CursorManager {
         }
         // Clear canvas when stopped
         if (this.ctx && this.canvas) {
-            this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+            this.ctx.clearRect(0, 0, this.logicalWidth || this.canvas.width, this.logicalHeight || this.canvas.height);
         }
         // Reset trail without destroying objects
         for (let i = 0; i < this.trail.length; i++) {
@@ -2350,13 +2354,19 @@ class CursorManager {
         }
     }
 
+    /**
+     * ⚡ Bolt Performance Optimization
+     * 💡 What: Cached `this.logicalWidth` and `this.logicalHeight` and used them instead of reading `this.canvas.width` and `this.canvas.height`.
+     * 🎯 Why: Reading DOM properties like `canvas.width` inside a high-frequency `requestAnimationFrame` loop forces synchronous C++ boundary crossings which adds CPU overhead.
+     * 📊 Impact: Eliminates O(N) DOM reads per frame, ensuring smoother rendering.
+     */
     animate() {
         if (!this.running) {
             this.looping = false;
             return;
         }
         
-        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.clearRect(0, 0, this.logicalWidth, this.logicalHeight);
         
         // Use cached RGB instead of calling getComputedStyle every frame
         const { r, g, b } = this.rgb;
@@ -3347,6 +3357,8 @@ class AudioVisualizer {
         this.animationId = null;
         this.gradientCache = [];
         this.lastHeight = 0;
+        this.logicalWidth = 0;
+        this.logicalHeight = 0;
 
         // Bind for RAF optimization
         this.draw = this.draw.bind(this);
@@ -3358,6 +3370,11 @@ class AudioVisualizer {
         
         this.ctx = this.canvas.getContext('2d');
         
+        this.logicalWidth = this.canvas.width;
+        this.logicalHeight = this.canvas.height;
+        // In this case, we'll just read them once in init, but if canvas resizes we might need a resize listener.
+        // The canvas doesn't seem to resize dynamically based on JS, it's 400x120 hardcoded in HTML.
+
         // Setup visibility observer to stop render loop when off-screen
         this.observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
@@ -3428,8 +3445,14 @@ class AudioVisualizer {
         if (!hasAudio) return;
         
         const ctx = this.ctx;
-        const width = this.canvas.width;
-        const height = this.canvas.height;
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Cached canvas dimensions as `this.logicalWidth` and `this.logicalHeight` to prevent reading DOM properties `this.canvas.width` and `this.canvas.height` on every frame.
+         * 🎯 Why: Accessing DOM properties inside a 60fps `requestAnimationFrame` loop forces synchronous JS-to-C++ boundary crossings, causing performance overhead.
+         * 📊 Impact: Eliminates DOM reads during the animation loop, reducing CPU usage.
+         */
+        const width = this.logicalWidth;
+        const height = this.logicalHeight;
         
         ctx.fillStyle = 'rgba(0, 0, 0, 0.2)';
         ctx.fillRect(0, 0, width, height);
@@ -3474,8 +3497,8 @@ class AudioVisualizer {
     drawStandby() {
         if (!this.canvas || !this.ctx) return;
         const ctx = this.ctx;
-        const width = this.canvas.width;
-        const height = this.canvas.height;
+        const width = this.logicalWidth || this.canvas.width;
+        const height = this.logicalHeight || this.canvas.height;
         
         ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
         ctx.fillRect(0, 0, width, height);


### PR DESCRIPTION
⚡ Bolt: Cache canvas dimensions in RAF loops

💡 **What:** Cached canvas dimensions (`this.logicalWidth`, `this.logicalHeight`) instead of reading DOM properties (`this.canvas.width`, `this.canvas.height`) in `AudioVisualizer` and `CursorManager` animation loops.
🎯 **Why:** Accessing DOM properties inside a 60fps `requestAnimationFrame` loop forces synchronous JS-to-C++ boundary crossings. Reading from standard JS class properties is significantly faster and prevents CPU overhead and potential layout thrashing.
📊 **Impact:** Eliminates O(N) DOM reads per frame for these elements, ensuring smoother rendering.
🔬 **Measurement:** Verify UI by serving the app locally and checking the console or timeline for reduced script execution time and no syntax errors (`node --check js/script.js src/scripts/script.js`).

---
*PR created automatically by Jules for task [12778246384235822116](https://jules.google.com/task/12778246384235822116) started by @kaitoartz*