### PR TITLE
⚡ Bolt: Cache `.boot-overlay` element in FrameRateMonitor checks

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -41,8 +41,18 @@ class FrameRateMonitor {
     }
 
     checkPerformance() {
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Cached the `.boot-overlay` DOM element during the first execution instead of re-querying it every second.
+         * 🎯 Why: `document.querySelector` is an expensive operation. Executing it repeatedly in a periodic monitor (even outside of requestAnimationFrame) adds unnecessary CPU overhead.
+         * 📊 Impact: Eliminates redundant DOM queries in the periodic performance checks.
+         */
+        if (this.bootOverlay === undefined) {
+            this.bootOverlay = document.querySelector('.boot-overlay');
+        }
+
         // Ignore during boot or if tab is hidden
-        if (document.hidden || (document.querySelector('.boot-overlay') && document.querySelector('.boot-overlay').style.display !== 'none')) return;
+        if (document.hidden || (this.bootOverlay && this.bootOverlay.style.display !== 'none')) return;
 
         this.history.push(this.fps);
         if (this.history.length > 5) this.history.shift();

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -43,8 +43,18 @@ class FrameRateMonitor {
     }
 
     checkPerformance() {
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Cached the `.boot-overlay` DOM element during the first execution instead of re-querying it every second.
+         * 🎯 Why: `document.querySelector` is an expensive operation. Executing it repeatedly in a periodic monitor (even outside of requestAnimationFrame) adds unnecessary CPU overhead.
+         * 📊 Impact: Eliminates redundant DOM queries in the periodic performance checks.
+         */
+        if (this.bootOverlay === undefined) {
+            this.bootOverlay = document.querySelector('.boot-overlay');
+        }
+
         // Ignore during boot or if tab is hidden
-        if (document.hidden || (document.querySelector('.boot-overlay') && document.querySelector('.boot-overlay').style.display !== 'none')) return;
+        if (document.hidden || (this.bootOverlay && this.bootOverlay.style.display !== 'none')) return;
 
         this.history.push(this.fps);
         if (this.history.length > 5) this.history.shift();


### PR DESCRIPTION
⚡ Bolt Performance Optimization:
Cached the `.boot-overlay` DOM element during the first execution instead of re-querying it every second in `FrameRateMonitor.checkPerformance()`.

💡 What: Cached the `.boot-overlay` DOM element during the first execution instead of re-querying it every second.
🎯 Why: `document.querySelector` is an expensive operation. Executing it repeatedly in a periodic monitor (even outside of requestAnimationFrame) adds unnecessary CPU overhead.
📊 Impact: Eliminates redundant DOM queries in the periodic performance checks.

---
*PR created automatically by Jules for task [11352145807983792577](https://jules.google.com/task/11352145807983792577) started by @kaitoartz*