### PR TITLE
⚡ Bolt: Optimize active section tracking to prevent layout thrashing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -62,3 +62,7 @@
 ## 2025-05-21 - Caching DOM lookups in periodic loops
 **Learning:** Calling `document.querySelector` inside an unconditionally firing periodic function (like `setInterval` or `requestAnimationFrame` loops) wastes CPU cycles on repeated DOM lookups, even if the result is static (like the `.boot-overlay` element in `FrameRateMonitor`).
 **Action:** Always cache the queried DOM element locally on the class/instance (e.g. `this.bootOverlay`) and reuse it instead of querying the DOM on every loop iteration.
+
+## 2025-05-22 - Layout Thrashing in Scroll Listeners
+**Learning:** Using `getBoundingClientRect` mixed with `.classList` mutations inside a scroll event listener—even when throttled by `requestAnimationFrame`—causes synchronous layout recalculations (layout thrashing) because the browser must update the layout to calculate the element's position before modifying styles in the same frame.
+**Action:** Always pre-calculate and cache expensive layout metrics like `offsetTop` on initialization and update them via a debounced `resize` listener. This eliminates the need to measure the DOM during high-frequency events like scrolling.

--- a/js/script.js
+++ b/js/script.js
@@ -4397,39 +4397,65 @@ document.addEventListener('DOMContentLoaded', () => {
     navBtns.forEach(btn => {
         const id = btn.getAttribute('href');
         const el = document.querySelector(id);
-        if (el) navSections.push({ btn, el });
+        if (el) navSections.push({ btn, el, offsetTop: 0 });
     });
 
     if (navSections.length > 0) {
         let ticking = false;
+
+        // Cache offsetTops
+        const updateOffsets = () => {
+            for (let i = 0; i < navSections.length; i++) {
+                const section = navSections[i];
+                section.offsetTop = section.el.getBoundingClientRect().top + window.scrollY;
+            }
+        };
+
+        // Initial calc
+        updateOffsets();
+
+        // Update on resize (debounced)
+        window.addEventListener('resize', debounce(updateOffsets, 200), { passive: true });
+
+        const updateActiveSection = () => {
+            /**
+             * ⚡ Bolt Performance Optimization
+             * 💡 What: Cached section offsets and avoided creating anonymous functions inside requestAnimationFrame. Replaced forEach with a standard for loop.
+             * 🎯 Why: Calling getBoundingClientRect() inside a scroll event loop forces synchronous layout recalculation (thrashing). Anonymous functions create GC pressure.
+             * 📊 Impact: Eliminates layout thrashing during scroll, ensuring butter-smooth navigation updates and reducing CPU overhead.
+             */
+            const scrollPos = window.scrollY + 120; // 120px offset to detect active section slightly before it hits the top
+            const scrollHeight = document.documentElement.scrollHeight;
+            const clientHeight = document.documentElement.clientHeight;
+
+            let activeBtn = navSections[0].btn;
+
+            // If near bottom of the page, activate the last section
+            if (window.scrollY + clientHeight >= scrollHeight - 50) {
+                activeBtn = navSections[navSections.length - 1].btn;
+            } else {
+                for (let i = navSections.length - 1; i >= 0; i--) {
+                    if (navSections[i].offsetTop <= scrollPos) {
+                        activeBtn = navSections[i].btn;
+                        break;
+                    }
+                }
+            }
+
+            for (let i = 0; i < navBtns.length; i++) {
+                 if (navBtns[i] === activeBtn) {
+                     navBtns[i].classList.add('nav-active');
+                 } else {
+                     navBtns[i].classList.remove('nav-active');
+                 }
+            }
+            ticking = false;
+        };
+
         window.addEventListener('scroll', () => {
             if (ticking) return;
             ticking = true;
-            requestAnimationFrame(() => {
-                const scrollPos = window.scrollY + 120; // 120px offset to detect active section slightly before it hits the top
-                const scrollHeight = document.documentElement.scrollHeight;
-                const clientHeight = document.documentElement.clientHeight;
-                
-                let activeBtn = navSections[0].btn;
-                
-                // If near bottom of the page, activate the last section
-                if (window.scrollY + clientHeight >= scrollHeight - 50) {
-                    activeBtn = navSections[navSections.length - 1].btn;
-                } else {
-                    for (let i = navSections.length - 1; i >= 0; i--) {
-                        const el = navSections[i].el;
-                        const elTop = el.getBoundingClientRect().top + window.scrollY;
-                        if (elTop <= scrollPos) {
-                            activeBtn = navSections[i].btn;
-                            break;
-                        }
-                    }
-                }
-                
-                navBtns.forEach(b => b.classList.remove('nav-active'));
-                activeBtn.classList.add('nav-active');
-                ticking = false;
-            });
+            requestAnimationFrame(updateActiveSection);
         }, { passive: true });
     }
 });

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -4397,39 +4397,65 @@ document.addEventListener('DOMContentLoaded', () => {
     navBtns.forEach(btn => {
         const id = btn.getAttribute('href');
         const el = document.querySelector(id);
-        if (el) navSections.push({ btn, el });
+        if (el) navSections.push({ btn, el, offsetTop: 0 });
     });
 
     if (navSections.length > 0) {
         let ticking = false;
+
+        // Cache offsetTops
+        const updateOffsets = () => {
+            for (let i = 0; i < navSections.length; i++) {
+                const section = navSections[i];
+                section.offsetTop = section.el.getBoundingClientRect().top + window.scrollY;
+            }
+        };
+
+        // Initial calc
+        updateOffsets();
+
+        // Update on resize (debounced)
+        window.addEventListener('resize', debounce(updateOffsets, 200), { passive: true });
+
+        const updateActiveSection = () => {
+            /**
+             * ⚡ Bolt Performance Optimization
+             * 💡 What: Cached section offsets and avoided creating anonymous functions inside requestAnimationFrame. Replaced forEach with a standard for loop.
+             * 🎯 Why: Calling getBoundingClientRect() inside a scroll event loop forces synchronous layout recalculation (thrashing). Anonymous functions create GC pressure.
+             * 📊 Impact: Eliminates layout thrashing during scroll, ensuring butter-smooth navigation updates and reducing CPU overhead.
+             */
+            const scrollPos = window.scrollY + 120; // 120px offset to detect active section slightly before it hits the top
+            const scrollHeight = document.documentElement.scrollHeight;
+            const clientHeight = document.documentElement.clientHeight;
+
+            let activeBtn = navSections[0].btn;
+
+            // If near bottom of the page, activate the last section
+            if (window.scrollY + clientHeight >= scrollHeight - 50) {
+                activeBtn = navSections[navSections.length - 1].btn;
+            } else {
+                for (let i = navSections.length - 1; i >= 0; i--) {
+                    if (navSections[i].offsetTop <= scrollPos) {
+                        activeBtn = navSections[i].btn;
+                        break;
+                    }
+                }
+            }
+
+            for (let i = 0; i < navBtns.length; i++) {
+                 if (navBtns[i] === activeBtn) {
+                     navBtns[i].classList.add('nav-active');
+                 } else {
+                     navBtns[i].classList.remove('nav-active');
+                 }
+            }
+            ticking = false;
+        };
+
         window.addEventListener('scroll', () => {
             if (ticking) return;
             ticking = true;
-            requestAnimationFrame(() => {
-                const scrollPos = window.scrollY + 120; // 120px offset to detect active section slightly before it hits the top
-                const scrollHeight = document.documentElement.scrollHeight;
-                const clientHeight = document.documentElement.clientHeight;
-                
-                let activeBtn = navSections[0].btn;
-                
-                // If near bottom of the page, activate the last section
-                if (window.scrollY + clientHeight >= scrollHeight - 50) {
-                    activeBtn = navSections[navSections.length - 1].btn;
-                } else {
-                    for (let i = navSections.length - 1; i >= 0; i--) {
-                        const el = navSections[i].el;
-                        const elTop = el.getBoundingClientRect().top + window.scrollY;
-                        if (elTop <= scrollPos) {
-                            activeBtn = navSections[i].btn;
-                            break;
-                        }
-                    }
-                }
-                
-                navBtns.forEach(b => b.classList.remove('nav-active'));
-                activeBtn.classList.add('nav-active');
-                ticking = false;
-            });
+            requestAnimationFrame(updateActiveSection);
         }, { passive: true });
     }
 });


### PR DESCRIPTION
⚡ Bolt: Optimize active section tracking to prevent layout thrashing

💡 What: Cached section offsets (`offsetTop`) instead of measuring them via `getBoundingClientRect` inside the high-frequency scroll event. The cached values are updated via a debounced resize listener. I also replaced `navBtns.forEach` with a standard `for` loop inside the `requestAnimationFrame` handler.
🎯 Why: Mixing DOM layout queries like `getBoundingClientRect` with DOM class mutations (`classList.add/remove`) inside a scroll loop forces synchronous layout recalculations (thrashing). Additionally, passing anonymous callback functions to array iteration methods inside RAF loops creates garbage collection overhead.
📊 Impact: Eliminates forced reflows during scrolling, ensuring smoother 60fps navigation updates and reducing CPU overhead on low-end devices.
🔬 Measurement: Verified scrolling still accurately tracks the active section via Playwright testing without raising console errors. Tested to ensure the `debounce` utility function exists and correctly processes resize events.

---
*PR created automatically by Jules for task [728189705932591381](https://jules.google.com/task/728189705932591381) started by @kaitoartz*