### PR TITLE
⚡ Bolt: Use DocumentFragment to batch DOM insertions in createWorld

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -722,6 +722,14 @@ class HyperScrollIntro {
     createWorld() {
         if (!this.world) return;
         
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced direct DOM appends in a loop with a DocumentFragment.
+         * 🎯 Why: Appending elements to a live DOM node multiple times causes layout thrashing and synchronous reflows.
+         * 📊 Impact: O(1) DOM insertions instead of O(N), improving rendering speed of the intro sequence.
+         */
+        const fragment = document.createDocumentFragment();
+
         // Create Items (Logic from User)
         for (let i = 0; i < this.config.itemCount; i++) {
             const el = document.createElement('div');
@@ -783,14 +791,14 @@ class HyperScrollIntro {
                     lastOffset: -1
                 });
             }
-            this.world.appendChild(el);
+            fragment.appendChild(el);
         }
 
         // Create Stars
         for (let i = 0; i < this.config.starCount; i++) {
             const el = document.createElement('div');
             el.className = 'intro-star';
-            this.world.appendChild(el);
+            fragment.appendChild(el);
             this.items.push({
                 el, type: 'star',
                 x: (Math.random() - 0.5) * 3000,
@@ -804,6 +812,8 @@ class HyperScrollIntro {
                 lastOffset: -1
             });
         }
+
+        this.world.appendChild(fragment);
     }
 
     initLenis() {

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -722,6 +722,14 @@ class HyperScrollIntro {
     createWorld() {
         if (!this.world) return;
         
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced direct DOM appends in a loop with a DocumentFragment.
+         * 🎯 Why: Appending elements to a live DOM node multiple times causes layout thrashing and synchronous reflows.
+         * 📊 Impact: O(1) DOM insertions instead of O(N), improving rendering speed of the intro sequence.
+         */
+        const fragment = document.createDocumentFragment();
+
         // Create Items (Logic from User)
         for (let i = 0; i < this.config.itemCount; i++) {
             const el = document.createElement('div');
@@ -783,14 +791,14 @@ class HyperScrollIntro {
                     lastOffset: -1
                 });
             }
-            this.world.appendChild(el);
+            fragment.appendChild(el);
         }
 
         // Create Stars
         for (let i = 0; i < this.config.starCount; i++) {
             const el = document.createElement('div');
             el.className = 'intro-star';
-            this.world.appendChild(el);
+            fragment.appendChild(el);
             this.items.push({
                 el, type: 'star',
                 x: (Math.random() - 0.5) * 3000,
@@ -804,6 +812,8 @@ class HyperScrollIntro {
                 lastOffset: -1
             });
         }
+
+        this.world.appendChild(fragment);
     }
 
     initLenis() {


### PR DESCRIPTION
💡 **What**: Replaced direct DOM node append operations inside loops with an off-DOM `DocumentFragment` construction in the `HyperScrollIntro.createWorld` method, both in `src/scripts/script.js` and `js/script.js`.

🎯 **Why**: When elements are appended to the live DOM iteratively within a loop, the browser is forced to parse and potentially reflow the page layout repeatedly, causing layout thrashing.

📊 **Impact**: Reduces synchronous reflows from O(N) (where N is the number of scrolling intro items/stars) to O(1). The exact impact ensures the intro sequence initializes faster without blocking the main UI thread with multiple layout thrashing triggers.

🔬 **Measurement**: Verify via browser dev tools performance tab that "Recalculate Style" and "Layout" warnings during page load are reduced. Functionality/visual parity was verified using automated Playwright regression snapshots.

---
*PR created automatically by Jules for task [6312287698874552179](https://jules.google.com/task/6312287698874552179) started by @kaitoartz*