### PR TITLE
⚡ Bolt: Replace expensive detectHardware calls with cached properties

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -65,3 +65,6 @@
 ## 2026-05-29 - Pre-calculate Section Offsets
 **Learning:** Calling `getBoundingClientRect()` inside a scroll event handler's `requestAnimationFrame` loop forces synchronous layout recalculations (reflows/layout thrashing), which kills scroll performance.
 **Action:** Pre-calculate and cache layout metrics (like absolute `top` offsets) on initialization, and update them via a debounced `resize` or `ResizeObserver` listener. Rely on `window.scrollY` during the high-frequency scroll event.
+## 2025-06-25 - Avoid Repeated Regex and Method Calls
+**Learning:** Evaluating regular expressions (like checking `navigator.userAgent`) and calling expensive detection methods (like `detectHardware()`) repeatedly in event handlers and component initializations creates significant CPU and GC overhead. `detectHardware()` in this codebase also spawned unhandled promises via the Battery API.
+**Action:** Detect hardware characteristics once during application boot, cache the result globally (e.g., in `performanceManager.hardware`), and use O(1) property lookups instead of invoking the detection method or regexes repeatedly.

--- a/js/script.js
+++ b/js/script.js
@@ -637,8 +637,13 @@ document.addEventListener('DOMContentLoaded', () => {
 class HyperScrollIntro {
     constructor() {
         // Detect performance and device characteristics
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-        const isMobile = performanceManager.detectHardware().isMobile || isMobileBrowser;
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced regex `userAgent` checks and `detectHardware()` with cached `performanceManager.hardware.isMobile`.
+         * 🎯 Why: Re-evaluating regex and calling `detectHardware()` delays initialization and wastes CPU cycles.
+         * 📊 Impact: Faster instantiation of components relying on hardware detection.
+         */
+        const isMobile = performanceManager.hardware.isMobile;
         const tier = performanceManager.hardware.tier;
         const isLowPerf = tier === 'low' || tier === 'medium';
         
@@ -807,7 +812,13 @@ class HyperScrollIntro {
     }
 
     initLenis() {
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced regex `userAgent` checks and `detectHardware()` with `performanceManager.hardware.isMobile`.
+         * 🎯 Why: Re-evaluating regex and calling `detectHardware()` delays initialization and wastes CPU cycles.
+         * 📊 Impact: Faster instantiation of components relying on hardware detection.
+         */
+        const isMobileBrowser = performanceManager.hardware.isMobile;
         const tier = performanceManager.hardware.tier;
         
         // VIRTUAL MODE: PC or High-performance devices, OR Mobile Browser (now virtualized for touch swipe)
@@ -849,7 +860,13 @@ class HyperScrollIntro {
     }
 
     bindEvents() {
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced regex `userAgent` checks and `detectHardware()` with `performanceManager.hardware.isMobile`.
+         * 🎯 Why: Re-evaluating regex and calling `detectHardware()` delays initialization and wastes CPU cycles.
+         * 📊 Impact: Faster instantiation of components relying on hardware detection.
+         */
+        const isMobileBrowser = performanceManager.hardware.isMobile;
 
         if (!isMobileBrowser) {
             // Desktop tilt controls
@@ -1696,7 +1713,13 @@ class DockManager {
                 if (el) {
                     el.addEventListener('click', (e) => {
                         e.stopPropagation();
-                        const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+                        /**
+                         * ⚡ Bolt Performance Optimization
+                         * 💡 What: Replaced expensive `detectHardware()` call and `userAgent` regex with cached `performanceManager.hardware.isMobile`.
+                         * 🎯 Why: `detectHardware()` executes regexes and creates Promises (via Battery API) on every call, causing GC overhead.
+                         * 📊 Impact: O(1) property lookup vs O(N) regex parsing and object/Promise allocation.
+                         */
+                        const isMobileDevice = performanceManager.hardware.isMobile;
                         if (isMobileDevice) {
                             this.toggleDock(dock);
                         }
@@ -1709,7 +1732,13 @@ class DockManager {
             if (burger) {
                 burger.addEventListener('click', (e) => {
                     e.stopPropagation();
-                    const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+                    /**
+                     * ⚡ Bolt Performance Optimization
+                     * 💡 What: Replaced expensive `detectHardware()` call and `userAgent` regex with cached `performanceManager.hardware.isMobile`.
+                     * 🎯 Why: `detectHardware()` executes regexes and creates Promises (via Battery API) on every call, causing GC overhead.
+                     * 📊 Impact: O(1) property lookup vs O(N) regex parsing and object/Promise allocation.
+                     */
+                    const isMobileDevice = performanceManager.hardware.isMobile;
                     // burgerMenu (#burgerMenu) toggles the dock open/close
                     if (burger.id === 'burgerMenu') {
                         if (typeof burgerMenuManager !== 'undefined') {
@@ -3050,7 +3079,13 @@ class BurgerMenuManager {
 
         if (!this.panel || this.docks.length === 0) return;
         
-        const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced expensive `detectHardware()` call and `userAgent` regex with cached `performanceManager.hardware.isMobile`.
+         * 🎯 Why: `detectHardware()` executes regexes and creates Promises (via Battery API) on every call, causing GC overhead.
+         * 📊 Impact: O(1) property lookup vs O(N) regex parsing and object/Promise allocation.
+         */
+        const isMobileDevice = performanceManager.hardware.isMobile;
 
         this.docks.forEach(dock => {
             // Note: .settings-toggle-btn and deco clicks are handled exclusively by DockManager
@@ -3707,7 +3742,13 @@ document.addEventListener('DOMContentLoaded', () => {
     let navBtns = document.querySelectorAll('.nav-dock .nav-btn');
     
     // PC-specific: Hide and filter out skills button
-    const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    /**
+     * ⚡ Bolt Performance Optimization
+     * 💡 What: Replaced expensive `detectHardware()` call and `userAgent` regex with cached `performanceManager.hardware.isMobile`.
+     * 🎯 Why: `detectHardware()` executes regexes and creates Promises (via Battery API) on every call, causing GC overhead.
+     * 📊 Impact: O(1) property lookup vs O(N) regex parsing and object/Promise allocation.
+     */
+    const isMobileDevice = performanceManager.hardware.isMobile;
     if (!isMobileDevice) {
         const skillsBtn = document.querySelector('.nav-dock .nav-btn[href="#skillsGrid"]');
         if (skillsBtn) skillsBtn.style.display = 'none';

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -637,8 +637,13 @@ document.addEventListener('DOMContentLoaded', () => {
 class HyperScrollIntro {
     constructor() {
         // Detect performance and device characteristics
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-        const isMobile = performanceManager.detectHardware().isMobile || isMobileBrowser;
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced regex `userAgent` checks and `detectHardware()` with cached `performanceManager.hardware.isMobile`.
+         * 🎯 Why: Re-evaluating regex and calling `detectHardware()` delays initialization and wastes CPU cycles.
+         * 📊 Impact: Faster instantiation of components relying on hardware detection.
+         */
+        const isMobile = performanceManager.hardware.isMobile;
         const tier = performanceManager.hardware.tier;
         const isLowPerf = tier === 'low' || tier === 'medium';
         
@@ -807,7 +812,13 @@ class HyperScrollIntro {
     }
 
     initLenis() {
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced regex `userAgent` checks and `detectHardware()` with `performanceManager.hardware.isMobile`.
+         * 🎯 Why: Re-evaluating regex and calling `detectHardware()` delays initialization and wastes CPU cycles.
+         * 📊 Impact: Faster instantiation of components relying on hardware detection.
+         */
+        const isMobileBrowser = performanceManager.hardware.isMobile;
         const tier = performanceManager.hardware.tier;
         
         // VIRTUAL MODE: PC or High-performance devices, OR Mobile Browser (now virtualized for touch swipe)
@@ -849,7 +860,13 @@ class HyperScrollIntro {
     }
 
     bindEvents() {
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced regex `userAgent` checks and `detectHardware()` with `performanceManager.hardware.isMobile`.
+         * 🎯 Why: Re-evaluating regex and calling `detectHardware()` delays initialization and wastes CPU cycles.
+         * 📊 Impact: Faster instantiation of components relying on hardware detection.
+         */
+        const isMobileBrowser = performanceManager.hardware.isMobile;
 
         if (!isMobileBrowser) {
             // Desktop tilt controls
@@ -1696,7 +1713,13 @@ class DockManager {
                 if (el) {
                     el.addEventListener('click', (e) => {
                         e.stopPropagation();
-                        const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+                        /**
+                         * ⚡ Bolt Performance Optimization
+                         * 💡 What: Replaced expensive `detectHardware()` call and `userAgent` regex with cached `performanceManager.hardware.isMobile`.
+                         * 🎯 Why: `detectHardware()` executes regexes and creates Promises (via Battery API) on every call, causing GC overhead.
+                         * 📊 Impact: O(1) property lookup vs O(N) regex parsing and object/Promise allocation.
+                         */
+                        const isMobileDevice = performanceManager.hardware.isMobile;
                         if (isMobileDevice) {
                             this.toggleDock(dock);
                         }
@@ -1709,7 +1732,13 @@ class DockManager {
             if (burger) {
                 burger.addEventListener('click', (e) => {
                     e.stopPropagation();
-                    const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+                    /**
+                     * ⚡ Bolt Performance Optimization
+                     * 💡 What: Replaced expensive `detectHardware()` call and `userAgent` regex with cached `performanceManager.hardware.isMobile`.
+                     * 🎯 Why: `detectHardware()` executes regexes and creates Promises (via Battery API) on every call, causing GC overhead.
+                     * 📊 Impact: O(1) property lookup vs O(N) regex parsing and object/Promise allocation.
+                     */
+                    const isMobileDevice = performanceManager.hardware.isMobile;
                     // burgerMenu (#burgerMenu) toggles the dock open/close
                     if (burger.id === 'burgerMenu') {
                         if (typeof burgerMenuManager !== 'undefined') {
@@ -3050,7 +3079,13 @@ class BurgerMenuManager {
 
         if (!this.panel || this.docks.length === 0) return;
         
-        const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Replaced expensive `detectHardware()` call and `userAgent` regex with cached `performanceManager.hardware.isMobile`.
+         * 🎯 Why: `detectHardware()` executes regexes and creates Promises (via Battery API) on every call, causing GC overhead.
+         * 📊 Impact: O(1) property lookup vs O(N) regex parsing and object/Promise allocation.
+         */
+        const isMobileDevice = performanceManager.hardware.isMobile;
 
         this.docks.forEach(dock => {
             // Note: .settings-toggle-btn and deco clicks are handled exclusively by DockManager
@@ -3707,7 +3742,13 @@ document.addEventListener('DOMContentLoaded', () => {
     let navBtns = document.querySelectorAll('.nav-dock .nav-btn');
     
     // PC-specific: Hide and filter out skills button
-    const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    /**
+     * ⚡ Bolt Performance Optimization
+     * 💡 What: Replaced expensive `detectHardware()` call and `userAgent` regex with cached `performanceManager.hardware.isMobile`.
+     * 🎯 Why: `detectHardware()` executes regexes and creates Promises (via Battery API) on every call, causing GC overhead.
+     * 📊 Impact: O(1) property lookup vs O(N) regex parsing and object/Promise allocation.
+     */
+    const isMobileDevice = performanceManager.hardware.isMobile;
     if (!isMobileDevice) {
         const skillsBtn = document.querySelector('.nav-dock .nav-btn[href="#skillsGrid"]');
         if (skillsBtn) skillsBtn.style.display = 'none';


### PR DESCRIPTION
💡 What: Replaced expensive `detectHardware()` call and `userAgent` regex with cached `performanceManager.hardware.isMobile`.
🎯 Why: `detectHardware()` executes regexes and creates unhandled Promises (via Battery API) on every click/init.
📊 Impact: O(1) property lookup vs O(N) regex parsing and object/Promise allocation.
🔬 Measurement: Verified that application initializes correctly without throwing errors, and that event handlers are no longer calling hardware detection functions directly.

---
*PR created automatically by Jules for task [6591960792695287841](https://jules.google.com/task/6591960792695287841) started by @kaitoartz*