### PR TITLE
⚡ Bolt: Replace redundant regex mobile detection with cached hardware property

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -65,3 +65,7 @@
 ## 2026-05-29 - Pre-calculate Section Offsets
 **Learning:** Calling `getBoundingClientRect()` inside a scroll event handler's `requestAnimationFrame` loop forces synchronous layout recalculations (reflows/layout thrashing), which kills scroll performance.
 **Action:** Pre-calculate and cache layout metrics (like absolute `top` offsets) on initialization, and update them via a debounced `resize` or `ResizeObserver` listener. Rely on `window.scrollY` during the high-frequency scroll event.
+
+## 2025-05-30 - Reuse cached performance hardware detection
+**Learning:** `navigator.userAgent` regex evaluations and `performanceManager.detectHardware()` are often called redundantly inside various initializers and event listeners (e.g. `DockManager`, `HyperScrollIntro`), wasting CPU and parsing overhead.
+**Action:** Always reuse the globally cached `performanceManager.hardware.isMobile` property instead of executing regex matchers or redundant hardware detections multiple times.

--- a/js/script.js
+++ b/js/script.js
@@ -637,8 +637,12 @@ document.addEventListener('DOMContentLoaded', () => {
 class HyperScrollIntro {
     constructor() {
         // Detect performance and device characteristics
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-        const isMobile = performanceManager.detectHardware().isMobile || isMobileBrowser;
+        // ⚡ Bolt Performance Optimization
+        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+        const isMobile = performanceManager.hardware.isMobile;
+        const isMobileBrowser = isMobile;
         const tier = performanceManager.hardware.tier;
         const isLowPerf = tier === 'low' || tier === 'medium';
         
@@ -807,7 +811,11 @@ class HyperScrollIntro {
     }
 
     initLenis() {
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        // ⚡ Bolt Performance Optimization
+        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+        const isMobileBrowser = performanceManager.hardware.isMobile;
         const tier = performanceManager.hardware.tier;
         
         // VIRTUAL MODE: PC or High-performance devices, OR Mobile Browser (now virtualized for touch swipe)
@@ -849,7 +857,11 @@ class HyperScrollIntro {
     }
 
     bindEvents() {
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        // ⚡ Bolt Performance Optimization
+        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+        const isMobileBrowser = performanceManager.hardware.isMobile;
 
         if (!isMobileBrowser) {
             // Desktop tilt controls
@@ -1696,7 +1708,11 @@ class DockManager {
                 if (el) {
                     el.addEventListener('click', (e) => {
                         e.stopPropagation();
-                        const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+                        // ⚡ Bolt Performance Optimization
+                        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+                        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+                        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+                        const isMobileDevice = performanceManager.hardware.isMobile;
                         if (isMobileDevice) {
                             this.toggleDock(dock);
                         }
@@ -1709,7 +1725,11 @@ class DockManager {
             if (burger) {
                 burger.addEventListener('click', (e) => {
                     e.stopPropagation();
-                    const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+                    // ⚡ Bolt Performance Optimization
+                    // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+                    // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+                    // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+                    const isMobileDevice = performanceManager.hardware.isMobile;
                     // burgerMenu (#burgerMenu) toggles the dock open/close
                     if (burger.id === 'burgerMenu') {
                         if (typeof burgerMenuManager !== 'undefined') {
@@ -3050,7 +3070,11 @@ class BurgerMenuManager {
 
         if (!this.panel || this.docks.length === 0) return;
         
-        const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        // ⚡ Bolt Performance Optimization
+        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+        const isMobileDevice = performanceManager.hardware.isMobile;
 
         this.docks.forEach(dock => {
             // Note: .settings-toggle-btn and deco clicks are handled exclusively by DockManager
@@ -3707,7 +3731,11 @@ document.addEventListener('DOMContentLoaded', () => {
     let navBtns = document.querySelectorAll('.nav-dock .nav-btn');
     
     // PC-specific: Hide and filter out skills button
-    const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    // ⚡ Bolt Performance Optimization
+    // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+    // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+    // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+    const isMobileDevice = performanceManager.hardware.isMobile;
     if (!isMobileDevice) {
         const skillsBtn = document.querySelector('.nav-dock .nav-btn[href="#skillsGrid"]');
         if (skillsBtn) skillsBtn.style.display = 'none';

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -637,8 +637,12 @@ document.addEventListener('DOMContentLoaded', () => {
 class HyperScrollIntro {
     constructor() {
         // Detect performance and device characteristics
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-        const isMobile = performanceManager.detectHardware().isMobile || isMobileBrowser;
+        // ⚡ Bolt Performance Optimization
+        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+        const isMobile = performanceManager.hardware.isMobile;
+        const isMobileBrowser = isMobile;
         const tier = performanceManager.hardware.tier;
         const isLowPerf = tier === 'low' || tier === 'medium';
         
@@ -807,7 +811,11 @@ class HyperScrollIntro {
     }
 
     initLenis() {
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        // ⚡ Bolt Performance Optimization
+        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+        const isMobileBrowser = performanceManager.hardware.isMobile;
         const tier = performanceManager.hardware.tier;
         
         // VIRTUAL MODE: PC or High-performance devices, OR Mobile Browser (now virtualized for touch swipe)
@@ -849,7 +857,11 @@ class HyperScrollIntro {
     }
 
     bindEvents() {
-        const isMobileBrowser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        // ⚡ Bolt Performance Optimization
+        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+        const isMobileBrowser = performanceManager.hardware.isMobile;
 
         if (!isMobileBrowser) {
             // Desktop tilt controls
@@ -1696,7 +1708,11 @@ class DockManager {
                 if (el) {
                     el.addEventListener('click', (e) => {
                         e.stopPropagation();
-                        const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+                        // ⚡ Bolt Performance Optimization
+                        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+                        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+                        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+                        const isMobileDevice = performanceManager.hardware.isMobile;
                         if (isMobileDevice) {
                             this.toggleDock(dock);
                         }
@@ -1709,7 +1725,11 @@ class DockManager {
             if (burger) {
                 burger.addEventListener('click', (e) => {
                     e.stopPropagation();
-                    const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+                    // ⚡ Bolt Performance Optimization
+                    // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+                    // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+                    // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+                    const isMobileDevice = performanceManager.hardware.isMobile;
                     // burgerMenu (#burgerMenu) toggles the dock open/close
                     if (burger.id === 'burgerMenu') {
                         if (typeof burgerMenuManager !== 'undefined') {
@@ -3050,7 +3070,11 @@ class BurgerMenuManager {
 
         if (!this.panel || this.docks.length === 0) return;
         
-        const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+        // ⚡ Bolt Performance Optimization
+        // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+        // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+        // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+        const isMobileDevice = performanceManager.hardware.isMobile;
 
         this.docks.forEach(dock => {
             // Note: .settings-toggle-btn and deco clicks are handled exclusively by DockManager
@@ -3707,7 +3731,11 @@ document.addEventListener('DOMContentLoaded', () => {
     let navBtns = document.querySelectorAll('.nav-dock .nav-btn');
     
     // PC-specific: Hide and filter out skills button
-    const isMobileDevice = performanceManager.detectHardware().isMobile || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    // ⚡ Bolt Performance Optimization
+    // 💡 What: Replaced redundant userAgent regex and detectHardware() with cached property.
+    // 🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling.
+    // 📊 Impact: Saves CPU cycles, prevents minor blocking operations.
+    const isMobileDevice = performanceManager.hardware.isMobile;
     if (!isMobileDevice) {
         const skillsBtn = document.querySelector('.nav-dock .nav-btn[href="#skillsGrid"]');
         if (skillsBtn) skillsBtn.style.display = 'none';


### PR DESCRIPTION
💡 What: Replaced redundant userAgent regex and detectHardware() with cached property `performanceManager.hardware.isMobile`.
🎯 Why: Avoids O(n) string parsing and repeated hardware detection during event handling (e.g. click events) and initializers.
📊 Impact: Saves CPU cycles, prevents minor blocking operations and garbage collection overhead.
🔬 Measurement: Verify that interacting with the Dock or Burger Menu does not incur regex evaluation overhead in Chrome DevTools Performance tab.

---
*PR created automatically by Jules for task [15824304034303523161](https://jules.google.com/task/15824304034303523161) started by @kaitoartz*