### PR TITLE
⚡ Bolt: Cache theme toggle icons in DockManager

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1676,10 +1676,12 @@ class DockManager {
         this.audioBtn = null;
         this.langBtn = null;
         this.isExpanded = false;
+        this.themeIcons = null;
     }
 
     init() {
         this.docks = document.querySelectorAll('.control-dock:not(.nav-dock)');
+        this.themeIcons = document.querySelectorAll('.theme-toggle-btn i');
 
         if (this.docks.length === 0) {
             console.warn('>> DOCK ERROR: No .control-dock found');
@@ -1800,11 +1802,19 @@ class DockManager {
         if (typeof audioManager !== 'undefined') audioManager.playClick();
     }
 
+    /**
+     * ⚡ Bolt Performance Optimization
+     * 💡 What: Cached the theme toggle icons (`this.themeIcons`) during initialization instead of querying the DOM every time a theme is updated.
+     * 🎯 Why: Querying the DOM via `document.querySelectorAll` inside a high-frequency UI interaction (like a theme toggle which may fire across multiple docks) forces unnecessary browser recalcs and wastes CPU cycles.
+     * 📊 Impact: Eliminates O(N) DOM queries on every theme update, avoiding redundant garbage collection and maintaining smooth interaction.
+     */
     updateAllThemes() {
         const isDark = document.body.classList.contains('theme-dark');
-        document.querySelectorAll('.theme-toggle-btn i').forEach(icon => {
-            icon.className = isDark ? 'fa-solid fa-moon theme-icon' : 'fa-solid fa-sun theme-icon';
-        });
+        if (this.themeIcons) {
+            this.themeIcons.forEach(icon => {
+                icon.className = isDark ? 'fa-solid fa-moon theme-icon' : 'fa-solid fa-sun theme-icon';
+            });
+        }
     }
 }
 

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -1676,10 +1676,12 @@ class DockManager {
         this.audioBtn = null;
         this.langBtn = null;
         this.isExpanded = false;
+        this.themeIcons = null;
     }
 
     init() {
         this.docks = document.querySelectorAll('.control-dock:not(.nav-dock)');
+        this.themeIcons = document.querySelectorAll('.theme-toggle-btn i');
 
         if (this.docks.length === 0) {
             console.warn('>> DOCK ERROR: No .control-dock found');
@@ -1800,11 +1802,19 @@ class DockManager {
         if (typeof audioManager !== 'undefined') audioManager.playClick();
     }
 
+    /**
+     * ⚡ Bolt Performance Optimization
+     * 💡 What: Cached the theme toggle icons (`this.themeIcons`) during initialization instead of querying the DOM every time a theme is updated.
+     * 🎯 Why: Querying the DOM via `document.querySelectorAll` inside a high-frequency UI interaction (like a theme toggle which may fire across multiple docks) forces unnecessary browser recalcs and wastes CPU cycles.
+     * 📊 Impact: Eliminates O(N) DOM queries on every theme update, avoiding redundant garbage collection and maintaining smooth interaction.
+     */
     updateAllThemes() {
         const isDark = document.body.classList.contains('theme-dark');
-        document.querySelectorAll('.theme-toggle-btn i').forEach(icon => {
-            icon.className = isDark ? 'fa-solid fa-moon theme-icon' : 'fa-solid fa-sun theme-icon';
-        });
+        if (this.themeIcons) {
+            this.themeIcons.forEach(icon => {
+                icon.className = isDark ? 'fa-solid fa-moon theme-icon' : 'fa-solid fa-sun theme-icon';
+            });
+        }
     }
 }
 


### PR DESCRIPTION
💡 What: Caches the `document.querySelectorAll('.theme-toggle-btn i')` NodeList as `this.themeIcons` during `DockManager.init()` and updates `updateAllThemes()` to iterate over the cached list.

🎯 Why: The `updateAllThemes()` method is called each time the theme is toggled. Previously, it redundantly re-queried the DOM for `.theme-toggle-btn i` elements on every toggle operation, which causes an O(N) DOM query cost. By caching the query during initialization, we eliminate unnecessary DOM traversal during user interactions.

📊 Impact: Eliminates O(N) redundant DOM queries on every theme toggle, making the toggle operation fractionally faster and saving main thread execution time.

🔬 Measurement: Verify visually or via tests that toggling the theme (clicking the sun/moon icon) correctly updates the icon classes between `fa-moon` and `fa-sun` without throwing errors.

---
*PR created automatically by Jules for task [2065884527709482489](https://jules.google.com/task/2065884527709482489) started by @kaitoartz*