### PR TITLE
⚡ Bolt: Throttle scroll event listener on Scroll to Top button

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -65,3 +65,6 @@
 ## 2026-05-29 - Pre-calculate Section Offsets
 **Learning:** Calling `getBoundingClientRect()` inside a scroll event handler's `requestAnimationFrame` loop forces synchronous layout recalculations (reflows/layout thrashing), which kills scroll performance.
 **Action:** Pre-calculate and cache layout metrics (like absolute `top` offsets) on initialization, and update them via a debounced `resize` or `ResizeObserver` listener. Rely on `window.scrollY` during the high-frequency scroll event.
+## 2025-06-18 - Unthrottled DOM mutations in scroll listeners
+**Learning:** Checking `window.scrollY` and mutating the DOM (`classList.add/remove`) inside an unthrottled `scroll` listener can lead to severe layout thrashing and scroll jank, because the browser attempts to execute the callback and repaint multiple times per frame.
+**Action:** Throttle high-frequency event listeners (like `scroll` and `resize`) using `requestAnimationFrame`, combine this with a boolean caching flag (e.g., `isScrollTopVisible`) to prevent redundant DOM writes, and use `{ passive: true }` to ensure scrolling isn't blocked.

--- a/js/script.js
+++ b/js/script.js
@@ -3685,13 +3685,32 @@ document.addEventListener('DOMContentLoaded', () => {
     // Scroll to Top Button
     const scrollTopBtn = document.getElementById('scrollTopBtn');
     if (scrollTopBtn) {
+        let isScrollTopVisible = false;
+        let tickingScrollTop = false;
+
         window.addEventListener('scroll', () => {
-            if (window.scrollY > 300) {
-                scrollTopBtn.classList.add('visible');
-            } else {
-                scrollTopBtn.classList.remove('visible');
+            if (!tickingScrollTop) {
+                window.requestAnimationFrame(() => {
+                    /**
+                     * ⚡ Bolt Performance Optimization
+                     * 💡 What: Throttled scroll listener using requestAnimationFrame and added `{ passive: true }`. Cached the visibility state `isScrollTopVisible`.
+                     * 🎯 Why: Unthrottled scroll listeners that perform DOM mutations (classList.add/remove) can cause layout thrashing and scroll jank.
+                     * 📊 Impact: Significantly smoother scrolling by ensuring DOM updates only happen once per frame and reducing unnecessary class mutations.
+                     */
+                    const shouldBeVisible = window.scrollY > 300;
+                    if (shouldBeVisible !== isScrollTopVisible) {
+                        isScrollTopVisible = shouldBeVisible;
+                        if (shouldBeVisible) {
+                            scrollTopBtn.classList.add('visible');
+                        } else {
+                            scrollTopBtn.classList.remove('visible');
+                        }
+                    }
+                    tickingScrollTop = false;
+                });
+                tickingScrollTop = true;
             }
-        });
+        }, { passive: true });
 
         scrollTopBtn.addEventListener('click', () => {
             if (typeof audioManager !== 'undefined') audioManager.playClick();

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -3685,13 +3685,32 @@ document.addEventListener('DOMContentLoaded', () => {
     // Scroll to Top Button
     const scrollTopBtn = document.getElementById('scrollTopBtn');
     if (scrollTopBtn) {
+        let isScrollTopVisible = false;
+        let tickingScrollTop = false;
+
         window.addEventListener('scroll', () => {
-            if (window.scrollY > 300) {
-                scrollTopBtn.classList.add('visible');
-            } else {
-                scrollTopBtn.classList.remove('visible');
+            if (!tickingScrollTop) {
+                window.requestAnimationFrame(() => {
+                    /**
+                     * ⚡ Bolt Performance Optimization
+                     * 💡 What: Throttled scroll listener using requestAnimationFrame and added `{ passive: true }`. Cached the visibility state `isScrollTopVisible`.
+                     * 🎯 Why: Unthrottled scroll listeners that perform DOM mutations (classList.add/remove) can cause layout thrashing and scroll jank.
+                     * 📊 Impact: Significantly smoother scrolling by ensuring DOM updates only happen once per frame and reducing unnecessary class mutations.
+                     */
+                    const shouldBeVisible = window.scrollY > 300;
+                    if (shouldBeVisible !== isScrollTopVisible) {
+                        isScrollTopVisible = shouldBeVisible;
+                        if (shouldBeVisible) {
+                            scrollTopBtn.classList.add('visible');
+                        } else {
+                            scrollTopBtn.classList.remove('visible');
+                        }
+                    }
+                    tickingScrollTop = false;
+                });
+                tickingScrollTop = true;
             }
-        });
+        }, { passive: true });
 
         scrollTopBtn.addEventListener('click', () => {
             if (typeof audioManager !== 'undefined') audioManager.playClick();


### PR DESCRIPTION
⚡ Bolt Performance Optimization

**💡 What:** 
Throttled the `scroll` event listener on `scrollTopBtn` using `requestAnimationFrame`, cached the visibility state to prevent redundant DOM updates, and added `{ passive: true }`.

**🎯 Why:** 
Unthrottled scroll listeners that execute DOM mutations (`classList.add/remove`) on every tick cause severe layout thrashing and scroll jank. The browser attempts to execute the callback and repaint multiple times per frame.

**📊 Impact:** 
Significantly smoother scrolling by ensuring DOM writes happen at most once per frame and only when the visibility state actually changes. Eliminates unnecessary class manipulation on the `scrollTopBtn`.

**🔬 Measurement:** 
Scroll performance on the page, especially on mobile/low-end devices, should exhibit fewer frame drops. Syntax verified via `node --check src/scripts/script.js`.

---
*PR created automatically by Jules for task [5094909896025863488](https://jules.google.com/task/5094909896025863488) started by @kaitoartz*