### PR TITLE
⚡ Bolt: [Implement O(1) Event Delegation in ProjectManager]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -69,3 +69,7 @@
 ## 2026-06-02 - Redundant hardware detection calls
 **Learning:** Calling `performanceManager.detectHardware()` repeatedly to check `isMobile` forces unnecessary recalculations of performance scores, CPU core counts, device memory, and connection types, wasting CPU cycles during initialization and UI interactions.
 **Action:** Always use the cached `performanceManager.hardware` object (e.g., `performanceManager.hardware.isMobile`) instead of invoking `detectHardware()` directly when checking system capabilities outside of the initial setup.
+
+## 2024-05-24 - Event Delegation in Vanilla JS List Rendering
+**Learning:** In a vanilla JS architecture, rendering dynamic lists by using `innerHTML` combined with a `querySelectorAll` loop to attach individual event listeners to each rendered item creates significant memory bloat and garbage collection overhead. Since the elements are repeatedly destroyed and re-created (e.g. during filtering), this pattern results in an O(N) penalty on every render cycle.
+**Action:** Always prefer attaching a single event listener to the parent container using event delegation. This reduces memory footprint and avoids expensive DOM querying loops, especially on lower-end devices or during frequent UI updates.

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -3415,6 +3415,20 @@ class ProjectManager {
                 if(typeof audioManager !== 'undefined') audioManager.playClick();
             });
         });
+
+        /**
+         * ⚡ Bolt Performance Optimization
+         * 💡 What: Implemented event delegation on the \`projectsGrid\` container for \`.view-project-btn\` clicks.
+         * 🎯 Why: Instead of attaching an event listener to every project card individually during every render (O(N)), we attach one listener to the container (O(1)).
+         * 📊 Impact: Eliminates redundant O(N) DOM querying (\`querySelectorAll\`) and garbage collection overhead during rapid filtering.
+         */
+        this.container.addEventListener('click', (e) => {
+            if (e.target.closest('.view-project-btn')) {
+                if(typeof audioManager !== 'undefined') {
+                    audioManager.playClick();
+                }
+            }
+        });
     }
 
     renderProjects(projects) {
@@ -3446,15 +3460,6 @@ class ProjectManager {
                 </div>
             </div>
         `).join('');
-
-        // Attach click handlers properly instead of inline 'onclick'
-        this.container.querySelectorAll('.view-project-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                if(typeof audioManager !== 'undefined') {
-                    audioManager.playClick();
-                }
-            });
-        });
     }
 
     setFilter(filter) {


### PR DESCRIPTION
💡 **What**: Replaced the O(N) `querySelectorAll` and individual `addEventListener` loop inside `ProjectManager.renderProjects` with a single O(1) delegated event listener attached to the parent `.projectsGrid` container in the initialization phase.

🎯 **Why**: When the user filtered projects, the application was destroying the DOM elements using `innerHTML`, rendering new ones, querying the DOM for all newly created `.view-project-btn` elements, and attaching individual event listeners. This created significant memory bloat, unnecessary DOM queries, and garbage collection overhead on every filter action.

📊 **Impact**: Eliminates O(N) DOM querying per render. Reduces memory allocations and garbage collection pauses, leading to smoother 60fps rendering during rapid UI filtering, especially on lower-end devices.

🔬 **Measurement**: Repeatedly click filter buttons rapidly. The Javascript execution time and garbage collection pauses measured in the Chrome DevTools Performance tab will be noticeably reduced.

---
*PR created automatically by Jules for task [4917280185330841879](https://jules.google.com/task/4917280185330841879) started by @kaitoartz*